### PR TITLE
goimport: fix glob if path contains test / example

### DIFF
--- a/goimport/import_factory.go
+++ b/goimport/import_factory.go
@@ -138,10 +138,10 @@ func glob(dirPath string) []string {
     files := make([]string, 0, len(fileNames))
 
     for _, v := range fileNames {
-        if isMatched("test", v) {
+        if isMatched("_test[.]go", v) {
             continue
         }
-        if isMatched("example", v) {
+        if isMatched("_example[.]go", v) {
             continue
         }
         files = append(files, v)


### PR DESCRIPTION
When the path contains either test or example, the regex used
in glob will match and therefore it won't return any files.
